### PR TITLE
Revise description

### DIFF
--- a/Assignments/ASSIGNMENT-1.ipynb
+++ b/Assignments/ASSIGNMENT-1.ipynb
@@ -558,9 +558,9 @@
     "Weekdays, the alarm should be \"7:00\" and on the weekend it should be \"10:00\". Unless we are on vacation -- then on weekdays it should be \"10:00\" and weekends it should be \"off\".\n",
     "\n",
     "\n",
-    "Encode the weeks days as ints in the following way: 0=Sun, 1=Mon, 2=Tue, ...6=Sat. Encode the vacation infromation as boolean. Your code should assign the correct time to a variable as a string (following this format: \"7:00\") and print it.\n",
+    "Encode the days of the week as ints in the following way: 0=Sun, 1=Mon, 2=Tue, ...6=Sat. Encode the vacation information as a boolean. Your code should assign the correct time to a variable as a string (following this format: \"7:00\") and print it.\n",
     "\n",
-    "Note: Encoding the days as an integer helps you with defining conditions. You can check whether the week day is in a certain interval (instead of writing code for every single day). "
+    "Note: Encoding the days as an integer helps you with defining conditions. You can check whether the day is in a certain interval (instead of writing code for every single day). "
    ]
   },
   {


### PR DESCRIPTION
Weekdays generally refer to non-weekend days. Hence I found 'days of the week' a more fitting phrase. Includes a surrounding spelling fix.